### PR TITLE
Set dev container time zone to Asia/Colombo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,8 @@
 			"extensions": ["James-Yu.latex-workshop"]
 		}
 	},
-	"remoteUser": "dev"
+	"remoteUser": "dev",
+	"containerEnv": {
+		"TZ": "Asia/Colombo"
+	}
 }


### PR DESCRIPTION
Setting the time zone of the dev container to Asia/Colombo, so the commit history of the repo is consistent regardless of whether the commit was made from inside the dev container or the host machine.

This is only beneficial to me, as I currently live in Sri Lanka. Might change in the future, hopefully!