### PR TITLE
Get the publisher of Adaptivo paper to a separate line

### DIFF
--- a/Sandaru_Jayasekara_CV.tex
+++ b/Sandaru_Jayasekara_CV.tex
@@ -83,7 +83,8 @@
 				\item \textbf{Adaptivo: A Personalized Adaptive E-Learning System based on Learning Styles and Prior Knowledge}
 				\begin{itemize}
 					\item Conference: 2022 Seventh International Conference on Informatics and Computing (ICIC)
-					\item DOI: \ttfamily \underbar{\href{https://doi.org/10.1109/ICIC56845.2022.10007006}{10.1109/ICIC56845.2022.10007006}}\normalfont , Publisher: IEEE
+					\item Publisher: IEEE
+					\item DOI: \ttfamily \underbar{\href{https://doi.org/10.1109/ICIC56845.2022.10007006}{10.1109/ICIC56845.2022.10007006}}
 				\end{itemize}
 			\end{itemize}
 		\end{cvsubsection}


### PR DESCRIPTION
Getting the 'Publisher' info of the Adaptivo paper publication to a separate line, just so that the content fit to page :wink: