### PR TITLE
Replace references section with hobbies and interests

### DIFF
--- a/Sandaru_Jayasekara_CV.tex
+++ b/Sandaru_Jayasekara_CV.tex
@@ -14,7 +14,7 @@
 
 	% Print content
 	\begin{cvsection}{Employment}
-		\begin{cvsubsection}[2]{Software Engineer, Intern \linebreak {\normalfont \small Product Team (Dev)}}{CAKE Engineering}{Sep 2021 -- Mar 2022 \linebreak {\normalfont \small Colombo, Sri Lanka}}			
+		\begin{cvsubsection}[2]{Software Engineer, Intern \linebreak {\normalfont \small Product Team (Developer)}}{CAKE Engineering}{Sep 2021 -- Mar 2022 \linebreak {\normalfont \small Colombo, Sri Lanka}}
 			\begin{itemize}
 				\item Worked on developing, testing and maintaining industry-standard online ordering and point-of-sale systems
 				\item Developed a feature-rich utility tool to automate and streamline several regular tasks of the development team

--- a/Sandaru_Jayasekara_CV.tex
+++ b/Sandaru_Jayasekara_CV.tex
@@ -99,10 +99,10 @@
 		\end{cvsubsection}
 	\end{cvsection}
 
-	\begin{cvsection}{References}
+	\begin{cvsection}{Interests}
 		\begin{cvsubsection}{}{}{}
 			\begin{itemize}
-				\item Available on request
+				\item Reading; music; guitar; coding; hacking; gaming; movies; open-source; Linux
 			\end{itemize}
 		\end{cvsubsection}
 	\end{cvsection}


### PR DESCRIPTION
This PR puts hobbies and interests in place of the unnecessary references section. This advice was given by an acquaintance with several years of industry experience, after I asked them to review my CV.

Resolves #5 