### PR TITLE
Reduce space between letters in the spaced-out name style

### DIFF
--- a/modest-cv.cls
+++ b/modest-cv.cls
@@ -172,7 +172,7 @@ Ligatures={TeX, NoCommon, NoDiscretionary}]{\mainfontface}
   \typeout {kokoko}
   \typeout \spaceskip
   \spaceskip \namespaceskip \relax
-  \textbf{\LARGE\textls[110]{\textsc{\@name}}}
+  \textbf{\LARGE\textls[100]{\textsc{\@name}}}
 }
 
 \makeatother


### PR DESCRIPTION
This resolves #10, decreasing the space between two letters in the styling used for the name at the top.

This is not necessary for the Times New Roman font, but doesn't hurt it either. Since I'm currently using Garamond anyways, I'll adjust it so that it fixes the issue for Garamond, but also doesn't create new issues for Times New Roman while doing so.