### PR TITLE
Refactor CV to be more ATS-friendly

### DIFF
--- a/Sandaru_Jayasekara_CV.tex
+++ b/Sandaru_Jayasekara_CV.tex
@@ -14,7 +14,7 @@
 
 	% Print content
 	\begin{cvsection}{Employment}
-		\begin{cvsubsection}[2]{Software Engineer, Intern}{CAKE Engineering}{Sep 2021 -- Mar 2022}{Colombo, Sri Lanka}
+		\begin{cvsubsection}[2]{CAKE Engineering}{Sep 2021 -- Mar 2022}{Software Engineer, Intern}{Colombo, Sri Lanka}
 			\begin{itemize}
 				\item Worked on developing, testing and maintaining industry-standard online ordering and point-of-sale systems
 				\item Developed a feature-rich utility tool to automate and streamline several regular tasks of the development team
@@ -26,7 +26,7 @@
 	\end{cvsection}
 
 	\begin{cvsection}{Education}
-		\begin{cvsubsection}[2]{BSc (Hons), Software Engineering}{Sri Lanka Institute of Information Technology}{Feb 2019 -- Mar 2023}{Malabe, Sri Lanka}
+		\begin{cvsubsection}[2]{BSc (Hons), Software Engineering}{Feb 2019 -- Mar 2023}{Sri Lanka Institute of Information Technology}{Malabe, Sri Lanka}
 			\begin{itemize}
 				\item Degree: Bachelor of Science Honours in Information Technology Specialising in Software Engineering
 				\item Graduated: March 2023. Second Class Honours Upper Division. GPA: 3.36/4.0

--- a/Sandaru_Jayasekara_CV.tex
+++ b/Sandaru_Jayasekara_CV.tex
@@ -5,7 +5,7 @@
 
 % Set personal data for the header
 \name{Sandaru Jayasekara}
-\address{Software Engineer \linebreak Kurunegala, Sri Lanka}
+\role{Software Engineer \linebreak Sri Lanka}
 \contacts{\href{tel:+94715510797}{+94 71 551 0797} \linebreak \ttfamily \underbar{\href{mailto:sandarulj@outlook.com}{sandarulj@outlook.com}}}
 
 \begin{document}

--- a/Sandaru_Jayasekara_CV.tex
+++ b/Sandaru_Jayasekara_CV.tex
@@ -14,7 +14,7 @@
 
 	% Print content
 	\begin{cvsection}{Employment}
-		\begin{cvsubsection}[2]{Software Engineer, Intern \linebreak {\normalfont \small Product Team (Developer)}}{CAKE Engineering}{Sep 2021 -- Mar 2022 \linebreak {\normalfont \small Colombo, Sri Lanka}}
+		\begin{cvsubsection}[2]{Software Engineer, Intern}{CAKE Engineering}{Sep 2021 -- Mar 2022}{Colombo, Sri Lanka}
 			\begin{itemize}
 				\item Worked on developing, testing and maintaining industry-standard online ordering and point-of-sale systems
 				\item Developed a feature-rich utility tool to automate and streamline several regular tasks of the development team
@@ -26,17 +26,17 @@
 	\end{cvsection}
 
 	\begin{cvsection}{Education}
-		\begin{cvsubsection}[2]{BSc (Hons), Software Engineering \linebreak {\normalfont \small Second Class Honours Upper Division}}{Sri Lanka Institute of \linebreak Information Technology}{Feb 2019 -- Mar 2023 \linebreak {\normalfont \small Malabe, Sri Lanka}}
+		\begin{cvsubsection}[2]{BSc (Hons), Software Engineering}{Sri Lanka Institute of Information Technology}{Feb 2019 -- Mar 2023}{Malabe, Sri Lanka}
 			\begin{itemize}
 				\item Degree: Bachelor of Science Honours in Information Technology Specialising in Software Engineering
-				\item Graduated: March 2023. GPA: 3.36/4.0
+				\item Graduated: March 2023. Second Class Honours Upper Division. GPA: 3.36/4.0
 				\item Coursework: OOP; Data Structures and Algorithms; OS and System Administration; Networking; Software Architecture; Secure Software Development; Distributed Systems; Parallel Computing; Internet and Web Technologies; Application Frameworks; Mobile App Development; Software Project Management; Databases; UX Engineering
 			\end{itemize}
 		\end{cvsubsection}
 	\end{cvsection}
 
 	\begin{cvsection}{Projects}
-		\begin{cvsubsection}{}{}{}
+		\begin{cvsubsection}{}{}{}{}
 			\begin{itemize}
 				\item \textbf{Adaptivo: E-Learning Platform} (2022). AI-powered e-learning platform that adapts itself to befit each individual student's learning preferences and knowledge levels
 				\begin{itemize}
@@ -60,7 +60,7 @@
 	\end{cvsection}
 
 	\begin{cvsection}{Skills}
-		\begin{cvsubsection}{}{}{}	
+		\begin{cvsubsection}{}{}{}{}
 			\begin{itemize}
 				\item \textbf{Languages:} Python; JavaScript; Java; C; TypeScript; Bash; HTML \& CSS; SQL
 				\item \textbf{Frameworks and Libraries:} Flask; React; Spring Boot; Node.js; Express; Angular; Android; Bootstrap
@@ -70,7 +70,7 @@
 	\end{cvsection}
 
 	\begin{cvsection}{Achievements}
-		\begin{cvsubsection}{}{}{}
+		\begin{cvsubsection}{}{}{}{}
 			\begin{itemize}
 				\item \textbf{Runners-up, SLIIT Codefest Algothon 2020:} Awarded 2nd prize for the annual competetive programming contest organized by the Sri Lanka Institute of Information Technology
 			\end{itemize}
@@ -78,7 +78,7 @@
 	\end{cvsection}
 
 	\begin{cvsection}{Publications}
-		\begin{cvsubsection}{}{}{}
+		\begin{cvsubsection}{}{}{}{}
 			\begin{itemize}
 				\item \textbf{Adaptivo: A Personalized Adaptive E-Learning System based on Learning Styles and Prior Knowledge}
 				\begin{itemize}
@@ -91,7 +91,7 @@
 	\end{cvsection}
 
 	\begin{cvsection}{Links}
-		\begin{cvsubsection}{}{}{}
+		\begin{cvsubsection}{}{}{}{}
 			\begin{itemize}
 				\item GitHub: \small \underbar{\url{https://github.com/SandaruLJ}} \normalsize
 				\item LinkedIn: \small \underbar{\url{https://www.linkedin.com/in/sandarulj}}
@@ -100,7 +100,7 @@
 	\end{cvsection}
 
 	\begin{cvsection}{Interests}
-		\begin{cvsubsection}{}{}{}
+		\begin{cvsubsection}{}{}{}{}
 			\begin{itemize}
 				\item Reading; music; guitar; coding; hacking; gaming; movies; open-source; Linux
 			\end{itemize}

--- a/modest-cv.cls
+++ b/modest-cv.cls
@@ -230,7 +230,7 @@ Ligatures={TeX, NoCommon, NoDiscretionary}]{\mainfontface}
   \notblank{#3}{\toggletrue{righttitledefined}}{}
   \ifboolexpr{togl {lefttitledefined} or togl {righttitledefined}}{
     \begin{tabu} to 1\textwidth { X[l,p] X[r,p] }
-      \textbf{#2} & \textbf{#3} \\ {#4} & {#5}
+      \textbf{#2} & \textbf{#3} \\ \small{#4} & \small{#5}
     \end{tabu}
     % Add space according to the specified number of lines
     \ifnumcomp{#1}{=}{1}{\vspace*{\aftersinglelinesubsectionheaderspace}}{

--- a/modest-cv.cls
+++ b/modest-cv.cls
@@ -225,13 +225,12 @@ Ligatures={TeX, NoCommon, NoDiscretionary}]{\mainfontface}
 \newtoggle{centertitledefined}
 \newtoggle{righttitledefined}
 
-\newenvironment{cvsubsection}[4][1]{
+\newenvironment{cvsubsection}[5][1]{
   \notblank{#2}{\toggletrue{lefttitledefined}}{}
-  \notblank{#3}{\toggletrue{centertitledefined}}{}
-  \notblank{#4}{\toggletrue{righttitledefined}}{}
-  \ifboolexpr{togl {lefttitledefined} or togl {centertitledefined} or togl {righttitledefined}}{
-    \begin{tabu} to 1\textwidth { X[l,p] X[c,p] X[r,p] }
-      \textbf{#2} & \textbf{#3} & \textbf{#4} \\
+  \notblank{#3}{\toggletrue{righttitledefined}}{}
+  \ifboolexpr{togl {lefttitledefined} or togl {righttitledefined}}{
+    \begin{tabu} to 1\textwidth { X[l,p] X[r,p] }
+      \textbf{#2} & \textbf{#3} \\ {#4} & {#5}
     \end{tabu}
     % Add space according to the specified number of lines
     \ifnumcomp{#1}{=}{1}{\vspace*{\aftersinglelinesubsectionheaderspace}}{

--- a/modest-cv.cls
+++ b/modest-cv.cls
@@ -150,14 +150,14 @@ Ligatures={TeX, NoCommon, NoDiscretionary}]{\mainfontface}
 %                            Header Setup and Printing                          -
 %--------------------------------------------------------------------------------
 
-% Address
+% Role
 \makeatletter
 
-\newcommand\address[1]{\def\@address{#1}}
-\address{}
+\newcommand\role[1]{\def\@role{#1}}
+\role{}
 
-\newcommand\printaddress{
-  \small{\@address}
+\newcommand\printrole{
+  \small{\@role}
 }
 
 \makeatother
@@ -193,7 +193,7 @@ Ligatures={TeX, NoCommon, NoDiscretionary}]{\mainfontface}
 \newcommand\makeheader{
   \begin{center}
     \begin{tabu} to 1\textwidth { X[l,m] X[2,c,m] X[r,m] }
-      \printaddress & \printname & \printcontacts \\
+      \printrole & \printname & \printcontacts \\
     \end{tabu}
   \end{center}
   \vspace*{\afterheaderspace}


### PR DESCRIPTION
Refactoring the CV to have a better chance at being parsed correctly by ATSs. The changes:
- Display subsection titles in two columns, so longer names don't break into the next line (unless they're really, really long!).
- Remove some unnecessary details that tend to mess with ATSs.
- Remove city because, 
    1. The above reason. Some ATSs mistake the '\<city\>, \<country\>' text for my name.
    2. Might get me filtered out prematurely because of the location. Plus, I'm primarily applying for remote jobs, for which the city would not really matter, and city is stated in my LinkedIn profile anyways.